### PR TITLE
Add tests for premature finish of one process

### DIFF
--- a/examples/barrier_remote_finish.c
+++ b/examples/barrier_remote_finish.c
@@ -1,0 +1,23 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include "../mimpi.h"
+#include "test.h"
+
+int main(int argc, char **argv)
+{
+    MIMPI_Init(false);
+
+    int const world_rank = MIMPI_World_rank();
+
+    if (world_rank != 1)
+    {
+        // Unmatched Barrier process 0 skips it.
+        // Should exit with MIMPI_ERROR_REMOTE_FINISHED
+        // during or after MIMPI_Finalize call in process 0.
+        MIMPI_Retcode ret = MIMPI_Barrier();
+        test_assert(ret == MIMPI_ERROR_REMOTE_FINISHED);
+    }
+
+    MIMPI_Finalize();
+    return test_success();
+}

--- a/examples/recv_remote_finish.c
+++ b/examples/recv_remote_finish.c
@@ -1,0 +1,26 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include "../mimpi.h"
+#include "test.h"
+
+int main(int argc, char **argv)
+{
+    MIMPI_Init(false);
+
+    int const world_rank = MIMPI_World_rank();
+
+    int const tag = 17;
+
+    char number;
+    if (world_rank == 1)
+    {
+        // Unmatched Recv.
+        // Should exit with MIMPI_ERROR_REMOTE_FINISHED
+        // during or after MIMPI_Finalize call in process 0.
+        MIMPI_Retcode ret = MIMPI_Recv(&number, 1, 0, tag);
+        test_assert(ret == MIMPI_ERROR_REMOTE_FINISHED);
+    }
+
+    MIMPI_Finalize();
+    return test_success();
+}

--- a/examples/send_remote_finish.c
+++ b/examples/send_remote_finish.c
@@ -1,0 +1,30 @@
+#include <stdbool.h>
+#include <stdio.h>
+#include "../mimpi.h"
+#include "test.h"
+
+#define MESSAGE "Litwo ojczyzno moja Ty jestes jak zdrowie ile Cie trzeba cenic ten tylko sie dowie, kto Cię stracil..."
+
+int main(int argc, char **argv)
+{
+    MIMPI_Init(false);
+
+    int const world_rank = MIMPI_World_rank();
+
+    int const tag = 17;
+
+    if (world_rank == 0)
+    {
+        sleep(1);
+        for (int i = 0; i < 500; ++i)
+        {
+            // Unmatched sends.
+            // None of those calls should block indefinitely,
+            // but they can either succeed or return MIMPI_ERROR_REMOTE_FINISH.
+            MIMPI_Send(MESSAGE, sizeof(MESSAGE), 1, tag);
+        }
+    }
+
+    MIMPI_Finalize();
+    return test_success();
+}

--- a/examples/send_remote_finish.c
+++ b/examples/send_remote_finish.c
@@ -3,7 +3,7 @@
 #include "../mimpi.h"
 #include "test.h"
 
-#define MESSAGE "Litwo ojczyzno moja Ty jestes jak zdrowie ile Cie trzeba cenic ten tylko sie dowie, kto Cię stracil..."
+#define MESSAGE "Litwo! Ojczyzno moja! ty jestes jak zdrowie.\nIle cie trzeba cenic, ten tylko sie dowie,\nKto cie stracil..."
 
 int main(int argc, char **argv)
 {

--- a/tests/basic/barrier_remote_finish.sh
+++ b/tests/basic/barrier_remote_finish.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+./run_test 1 4 examples_build/barrier_remote_finish

--- a/tests/basic/recv_remote_finish.sh
+++ b/tests/basic/recv_remote_finish.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+./run_test 1 4 examples_build/recv_remote_finish

--- a/tests/basic/send_remote_finish.sh
+++ b/tests/basic/send_remote_finish.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+./run_test 4s 10 examples_build/send_remote_finish


### PR DESCRIPTION
Add tests for situations when one process calls
MIMPI_Finalize before others do (they have pending operations).