### PR TITLE
Drobna poprawka do testów

### DIFF
--- a/examples/concurrent_receive.c
+++ b/examples/concurrent_receive.c
@@ -8,7 +8,7 @@ int main() {
     if (MIMPI_World_rank() != 0) {
         int a[10];
         for (int i = 0; i < 10000; i++) {
-            MIMPI_Send(a, 10 * sizeof(int), 0, MIMPI_ANY_TAG);
+            MIMPI_Send(a, 10 * sizeof(int), 0, 1);
         }
     }
 


### PR DESCRIPTION
W teście concurrent_receive wysyłałem dane z tagiem MIMPI_ANY_TAG.