### PR TITLE
Test enhancements

### DIFF
--- a/examples/deadlock.c
+++ b/examples/deadlock.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include "../mimpi.h"
+#include "mimpi_err.h"
 #include "test.h"
 
 int main(int argc, char **argv)
@@ -14,9 +15,9 @@ int main(int argc, char **argv)
 
     char number;
     // First deadlock
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
     // Second deadlock
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
 
     MIMPI_Finalize();
     return test_success();

--- a/examples/deadlock1.c
+++ b/examples/deadlock1.c
@@ -2,6 +2,7 @@
 #include <stdbool.h>
 
 #include "../mimpi.h"
+#include "mimpi_err.h"
 #include "test.h"
 
 int main(int argc, char **argv)
@@ -12,11 +13,11 @@ int main(int argc, char **argv)
     int partner_rank = (world_rank / 2 * 2) + 1 - world_rank % 2;
 
     char number = 42;
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
     MIMPI_Finalize();
     return test_success();
 }

--- a/examples/deadlock1.c
+++ b/examples/deadlock1.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv)
     int const world_rank = MIMPI_World_rank();
     int partner_rank = (world_rank / 2 * 2) + 1 - world_rank % 2;
 
-    char number;
+    char number = 42;
     assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
     assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
     assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);

--- a/examples/deadlock2.c
+++ b/examples/deadlock2.c
@@ -11,7 +11,7 @@ int main(int argc, char **argv)
     int const world_rank = MIMPI_World_rank();
     int partner_rank = (world_rank / 2 * 2) + 1 - world_rank % 2;
 
-    char number;
+    char number = 42;
     MIMPI_Send(&number, 1, partner_rank, 2);
     assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
     MIMPI_Finalize();

--- a/examples/deadlock2.c
+++ b/examples/deadlock2.c
@@ -3,6 +3,7 @@
 
 #include "test.h"
 #include "../mimpi.h"
+#include "mimpi_err.h"
 
 int main(int argc, char **argv)
 {
@@ -13,7 +14,7 @@ int main(int argc, char **argv)
 
     char number = 42;
     MIMPI_Send(&number, 1, partner_rank, 2);
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
     MIMPI_Finalize();
     return test_success();
 }

--- a/examples/deadlock3.c
+++ b/examples/deadlock3.c
@@ -15,8 +15,8 @@ int main(int argc, char **argv)
     char number = 42;
     ASSERT_MIMPI_OK(MIMPI_Send(&number, 1, partner_rank, 2));
     ASSERT_MIMPI_OK(MIMPI_Send(&number, 1, partner_rank, 1));
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_SUCCESS);
-    assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_OK(MIMPI_Recv(&number, 1, partner_rank, 1));
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED); 
     MIMPI_Finalize();
     return test_success();
 }

--- a/examples/deadlock3.c
+++ b/examples/deadlock3.c
@@ -12,7 +12,7 @@ int main(int argc, char **argv)
     int const world_rank = MIMPI_World_rank();
     int partner_rank = (world_rank / 2 * 2) + 1 - world_rank % 2;
 
-    char number;
+    char number = 42;
     ASSERT_MIMPI_OK(MIMPI_Send(&number, 1, partner_rank, 2));
     ASSERT_MIMPI_OK(MIMPI_Send(&number, 1, partner_rank, 1));
     assert(MIMPI_Recv(&number, 1, partner_rank, 1) == MIMPI_SUCCESS);

--- a/examples/deadlock4.c
+++ b/examples/deadlock4.c
@@ -9,7 +9,7 @@ int main(int argc, char **argv)
     MIMPI_Init(true);
 
     int const world_rank = MIMPI_World_rank();
-    char number;
+    char number = 42;
 
     if (world_rank == 0) {
         assert(MIMPI_Recv(&number, 1, 1, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);

--- a/examples/deadlock4.c
+++ b/examples/deadlock4.c
@@ -3,6 +3,7 @@
 
 #include "test.h"
 #include "../mimpi.h"
+#include "mimpi_err.h"
 
 int main(int argc, char **argv)
 {
@@ -12,10 +13,10 @@ int main(int argc, char **argv)
     char number = 42;
 
     if (world_rank == 0) {
-        assert(MIMPI_Recv(&number, 1, 1, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
-        assert(MIMPI_Recv(&number, 1, 2, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
+        ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, 1, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
+        ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, 2, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
     } else {
-        assert(MIMPI_Recv(&number, 1, 0, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
+        ASSERT_MIMPI_RETCODE(MIMPI_Recv(&number, 1, 0, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
     }
     MIMPI_Finalize();
     return test_success();

--- a/examples/deadlock5.c
+++ b/examples/deadlock5.c
@@ -4,6 +4,7 @@
 
 #include "test.h"
 #include "../mimpi.h"
+#include "mimpi_err.h"
 
 int main(int argc, char **argv)
 {
@@ -17,7 +18,7 @@ int main(int argc, char **argv)
     if (world_rank == 0) {
         MIMPI_Send(data, sizeof(int) * 1000000, partner_rank, 2);
     }
-    assert(MIMPI_Recv(data, sizeof(int) * 1000000, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(data, sizeof(int) * 1000000, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
     MIMPI_Finalize();
     return test_success();
 }

--- a/examples/deadlock5.c
+++ b/examples/deadlock5.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "test.h"
 #include "../mimpi.h"
@@ -11,6 +12,8 @@ int main(int argc, char **argv)
     int const world_rank = MIMPI_World_rank();
     int partner_rank = (world_rank / 2 * 2) + 1 - world_rank % 2;
     int data[1000000];
+    memset(data, 42, sizeof(data));
+    
     if (world_rank == 0) {
         MIMPI_Send(data, sizeof(int) * 1000000, partner_rank, 2);
     }

--- a/examples/deadlock6.c
+++ b/examples/deadlock6.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "test.h"
 #include "../mimpi.h"
@@ -11,6 +12,8 @@ int main(int argc, char **argv)
     int const world_rank = MIMPI_World_rank();
     int partner_rank = (world_rank / 2 * 2) + 1 - world_rank % 2;
     int data[1000000];
+    memset(data, 42, sizeof(data));
+
     if (world_rank == 0) {
         MIMPI_Send(data, sizeof(int) * 1000000, partner_rank, 2);
         MIMPI_Send(data, sizeof(int) * 1000000, partner_rank, 2);

--- a/examples/deadlock6.c
+++ b/examples/deadlock6.c
@@ -4,6 +4,7 @@
 
 #include "test.h"
 #include "../mimpi.h"
+#include "mimpi_err.h"
 
 int main(int argc, char **argv)
 {
@@ -24,7 +25,7 @@ int main(int argc, char **argv)
         MIMPI_Send(data, sizeof(int) * 1000000, partner_rank, 2);
         MIMPI_Send(data, sizeof(int) * 1000000, partner_rank, 2);
     }
-    assert(MIMPI_Recv(data, sizeof(int) * 1000000, partner_rank, 1) == MIMPI_ERROR_DEADLOCK_DETECTED);
+    ASSERT_MIMPI_RETCODE(MIMPI_Recv(data, sizeof(int) * 1000000, partner_rank, 1), MIMPI_ERROR_DEADLOCK_DETECTED);
     MIMPI_Finalize();
     return test_success();
 }

--- a/examples/mimpi_err.h
+++ b/examples/mimpi_err.h
@@ -15,16 +15,18 @@ static char const *const print_mimpi_error(MIMPI_Retcode const ret) {
     }
 }
 
-#define ASSERT_MIMPI_OK(expr)                                                                      \
+#define ASSERT_MIMPI_OK(expr) ASSERT_MIMPI_RETCODE(expr, MIMPI_SUCCESS)
+
+#define ASSERT_MIMPI_RETCODE(expr, expected)                                                       \
     do {                                                                                           \
-        MIMPI_Retcode ret = expr;                                                                  \
-        if (ret != MIMPI_SUCCESS) {                                                                \
+        MIMPI_Retcode _ret = expr;                                                                 \
+        if (_ret != expected) {                                                                    \
             fprintf(                                                                               \
                 stderr,                                                                            \
                 "MIMPI command failed: %s\n\tIn function %s() in %s line %d.\n\t Code: %i - %s\n", \
-                #expr, __func__, __FILE__, __LINE__, ret, print_mimpi_error(ret)                   \
+                #expr, __func__, __FILE__, __LINE__, _ret, print_mimpi_error(_ret)                 \
             );                                                                                     \
-            exit(ret);                                                                             \
+            exit(_ret);                                                                            \
         }                                                                                          \
     } while(0)
 

--- a/examples/test.h
+++ b/examples/test.h
@@ -5,7 +5,7 @@
 
 #define SUCCESS_MARKER "<<success>>\n"
 
-int test_success()
+static inline int test_success()
 {
     // below unchecked syscall return code
     write(STDERR_FILENO, SUCCESS_MARKER, sizeof(SUCCESS_MARKER));


### PR DESCRIPTION
- avoided UB (reading uninit memory) in examples,
- introduced `ASSERT_MIMPI_RETCODE` and used it in deadlock tests.