### PR TITLE
fix bug in ASSERT_ZERO

### DIFF
--- a/channel.c
+++ b/channel.c
@@ -23,7 +23,7 @@ shouldn't observably differ in any way other than execution duration.
             fprintf(                                                                         \
                 stderr,                                                                      \
                 "ERROR: Failed: %s\n\tIn function %s() in %s line %d.\n\tErrno: (%d; %s)\n", \
-                #expr, __func__, __FILE__, __LINE__, errno, strerror(errno)                  \
+                #expr, __func__, __FILE__, __LINE__, _errno, strerror(_errno)                  \
             );                                                                               \
     } while(0)
 


### PR DESCRIPTION
`errno` global variable was queried for error code instead of checking content of `_errno` local variable.