### PR TITLE
Flush stdout in extended_hello test

### DIFF
--- a/examples/extended_hello.c
+++ b/examples/extended_hello.c
@@ -48,6 +48,7 @@ int main(int argc, char **argv)
     for(int i=0; i<argc; i++){
         printf("%dth arg: %s\n", i, argv[i]);
     }
+    fflush(stdout);
 
     MIMPI_Finalize();
     return test_success();


### PR DESCRIPTION
`stdout` should be flushed after `printf` statements, otherwise output order may be incorrect for a correct solution