### PR TITLE
avoid stack corruption due to large arrays

### DIFF
--- a/examples/deadlock5.c
+++ b/examples/deadlock5.c
@@ -6,13 +6,13 @@
 #include "../mimpi.h"
 #include "mimpi_err.h"
 
+int data[1000000];
 int main(int argc, char **argv)
 {
     MIMPI_Init(true);
 
     int const world_rank = MIMPI_World_rank();
     int partner_rank = (world_rank / 2 * 2) + 1 - world_rank % 2;
-    int data[1000000];
     memset(data, 42, sizeof(data));
     
     if (world_rank == 0) {

--- a/examples/deadlock6.c
+++ b/examples/deadlock6.c
@@ -6,13 +6,14 @@
 #include "../mimpi.h"
 #include "mimpi_err.h"
 
+int data[1000000];
+
 int main(int argc, char **argv)
 {
     MIMPI_Init(true);
 
     int const world_rank = MIMPI_World_rank();
     int partner_rank = (world_rank / 2 * 2) + 1 - world_rank % 2;
-    int data[1000000];
     memset(data, 42, sizeof(data));
 
     if (world_rank == 0) {


### PR DESCRIPTION
`valgrind` complains (and it is probably right) that stack is being corrupted in `deadlock5` and `deadlock6`. It is due to large arrays being allocated on stack. This is solved by allocating them in static memory (BSS region).